### PR TITLE
Don't listen to cancelled physics events

### DIFF
--- a/src/de/Ste3et_C0st/FurnitureLib/ShematicLoader/ProjectLoader.java
+++ b/src/de/Ste3et_C0st/FurnitureLib/ShematicLoader/ProjectLoader.java
@@ -15,7 +15,6 @@ import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import org.bukkit.event.EventPriority;
 import org.bukkit.event.block.BlockPhysicsEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.material.MaterialData;

--- a/src/de/Ste3et_C0st/FurnitureLib/ShematicLoader/ProjectLoader.java
+++ b/src/de/Ste3et_C0st/FurnitureLib/ShematicLoader/ProjectLoader.java
@@ -15,6 +15,7 @@ import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.block.BlockPhysicsEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.material.MaterialData;

--- a/src/de/Ste3et_C0st/FurnitureLib/ShematicLoader/ProjectLoader.java
+++ b/src/de/Ste3et_C0st/FurnitureLib/ShematicLoader/ProjectLoader.java
@@ -138,7 +138,7 @@ public class ProjectLoader extends Furniture implements Listener{
 		e.remove();
 	}
 	
-	@EventHandler
+	@EventHandler(ignoreCancelled = true)
 	private void onPhysiks(BlockPhysicsEvent e){
 		  if(getObjID() == null) return;
 		  if(getObjID().getSQLAction().equals(SQLAction.REMOVE)){return;}


### PR DESCRIPTION
Should increase performance significantly when there's a lot of cancelled BlockPhysicsEvents