### PR TITLE
Add Permissions Kit Crafting Permission

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /bin/
 /target/
+.classpath

--- a/src/de/Ste3et_C0st/FurnitureLib/Events/ChunkOnLoad.java
+++ b/src/de/Ste3et_C0st/FurnitureLib/Events/ChunkOnLoad.java
@@ -308,6 +308,24 @@ public class ChunkOnLoad implements Listener{
 		e.removeItem();
 	}
 	
+	private boolean hasPermissions(Player p, String name) {
+		if(p.isOp()) return true;
+		if(FurnitureLib.getInstance().getPermission().hasPerm(p,"furniture.admin")) return true;
+		if(FurnitureLib.getInstance().getPermission().hasPerm(p,"furniture.player")) return true;
+		if(FurnitureLib.getInstance().getPermission().hasPerm(p,"furniture.craft.*")) return true;
+		if(FurnitureLib.getInstance().getPermission().hasPerm(p,"furniture.craft." + name)) return true;
+		if(FurnitureLib.getInstance().getPermissionList()!=null){
+			for(String s : FurnitureLib.getInstance().getPermissionList().keySet()){
+				if(FurnitureLib.getInstance().getPermission().hasPerm(p, "furniture.craft.all." + s)){
+					if(FurnitureLib.getInstance().getPermissionList().get(s).contains(name)){
+						return true;
+					}
+				}
+			}
+		}
+		return false;
+	}
+	
 	@EventHandler
 	private void onCrafting(PrepareItemCraftEvent e){
 		if(FurnitureLib.getInstance().getFurnitureManager().getProjects().isEmpty()){return;}
@@ -319,7 +337,7 @@ public class ChunkOnLoad implements Listener{
 		is.setAmount(1);
 		for(Project pro : FurnitureLib.getInstance().getFurnitureManager().getProjects()){
 			if(is.equals(pro.getCraftingFile().getRecipe().getResult())){
-				if(!FurnitureLib.getInstance().getPermission().hasPerm(p,"furniture.craft.*") && !FurnitureLib.getInstance().getPermission().hasPerm(p,"furniture.craft." + pro.getSystemID()) && !FurnitureLib.getInstance().getPermission().hasPerm(p,"furniture.player") && !FurnitureLib.getInstance().getPermission().hasPerm(p,"furniture.admin")){
+				if(!hasPermissions(p, pro.getSystemID())){
 					e.getInventory().setResult(null);
 				}
 			}


### PR DESCRIPTION
This adds the permission, "furniture.craft.all.'furnitureKit'" to allow players to craft furniture from a furniture kit. Also adds a method, "hasPermissions", to make updating the permission check a little easier.

So, if a player has the permission, "furniture.craft.all.vip", they'll be able to craft all the furniture from the vip furniture kit.