### PR TITLE
Allow TrapDoors to be rotated with the .Rotation setting

### DIFF
--- a/src/de/Ste3et_C0st/FurnitureLib/ShematicLoader/ProjectLoader.java
+++ b/src/de/Ste3et_C0st/FurnitureLib/ShematicLoader/ProjectLoader.java
@@ -15,6 +15,8 @@ import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.data.Directional;
+import org.bukkit.block.data.Bisected.Half;
+import org.bukkit.block.data.type.TrapDoor;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryType;
@@ -201,6 +203,11 @@ public class ProjectLoader extends Furniture{
 						BlockFace face = BlockFace.valueOf(config.getString(header+".projectData.blockList." + s + ".Rotation"));
 						material.setBlockFace(face);
 					}
+					//handle materials that have the Bisected/Half interface
+					if(config.isSet(header+".projectData.blockList." + s + ".Half")){
+						Half half = Half.valueOf(config.getString(header+".projectData.blockList." + s + ".Half"));
+						material.setHalf(half);
+					}
 					
 					if(config.isSet(header+".projectData.blockList." + s + ".Inventory")){
 						InventoryType type = InventoryType.valueOf(config.getString(header+".projectData.blockList." + s + ".Inventory.type"));
@@ -307,7 +314,18 @@ public class ProjectLoader extends Furniture{
 									getLutil().setBed(face, blockLocation, material.getMaterial());
 									registerBlock(block);
 									continue;
-								}if(material.getMaterial().name().endsWith("DOOR")){
+								}
+								if(material.getMaterial().name().endsWith("TRAPDOOR")){
+									//Bottom block
+									TrapDoor d = (TrapDoor) state.getBlockData();
+									d.setHalf(material.getHalf());
+									d.setFacing(face);
+									state.setBlockData(d);
+									state.update(true);
+									registerBlock(block);
+									continue;
+								}
+								if(material.getMaterial().name().endsWith("DOOR")){
 									//Bottom block
 									Door d = (Door) state.getData();
 									d.setTopHalf(false);

--- a/src/de/Ste3et_C0st/FurnitureLib/ShematicLoader/ProjectMaterial.java
+++ b/src/de/Ste3et_C0st/FurnitureLib/ShematicLoader/ProjectMaterial.java
@@ -2,12 +2,14 @@ package de.Ste3et_C0st.FurnitureLib.ShematicLoader;
 
 import org.bukkit.Material;
 import org.bukkit.block.BlockFace;
+import org.bukkit.block.data.Bisected.Half;
 import org.bukkit.inventory.Inventory;
 
 public class ProjectMaterial {
 
 	private Material mat;
 	private BlockFace face = BlockFace.NORTH;
+	private Half half = Half.TOP;
 	private boolean rootable = false;
 	private Inventory inv = null;
 	
@@ -25,6 +27,8 @@ public class ProjectMaterial {
 	public Material getMaterial(){return this.mat;}
 	public Inventory getInventory(){return this.inv;}
 	public boolean isDirectional(){return this.rootable;}
+	public Half getHalf(){return this.half;}
 	public void setBlockFace(BlockFace face) {this.face = face;this.rootable = true;}
 	public void setInventory(Inventory inv) {this.inv = inv;}
+	public void setHalf(Half half) {this.half = half;}
 }


### PR DESCRIPTION
[ProjectMaterial]
 - Add variable to store BlockHalf setting.
[ProjectLoader]
- Create .Half config option for Half/Bisected interface.
- Seperate if for TRAPDOOR before DOOR to handle TRAPDOOR facing and Half.