### PR TITLE
Update fSerializer.java

### DIFF
--- a/src/de/Ste3et_C0st/FurnitureLib/main/entity/fSerializer.java
+++ b/src/de/Ste3et_C0st/FurnitureLib/main/entity/fSerializer.java
@@ -100,7 +100,7 @@ public abstract class fSerializer extends fProtocol{
 		if (flag) {
 			getWatcher().setObject(new WrappedDataWatcherObject(field, Registry.get(Byte.class)), (byte) (b0 | 1 << i));
 		} else {
-			getWatcher().setObject(new WrappedDataWatcherObject(field, Registry.get(Byte.class)), Byte.valueOf((byte) (b0 & (1 << i ^ 0xFFFFFFFF))));
+			getWatcher().setObject(new WrappedDataWatcherObject(field, Registry.get(Byte.class)), Byte.valueOf((byte) (b0 & ~(1 << i))));
 		}
 	}
 	


### PR DESCRIPTION
Easier to understand unset bit operation.

Rather than EXOR the shit (say 00001000) with the max of a unsigned byte (11111111) to produce (11110111),  
Simply complement the shift, much easier logically to understand and read with same result.

Not a big change, but took me 10 mins to understand what you was doing